### PR TITLE
fix: Handle missing field_activity_color

### DIFF
--- a/src/Controller/FullCalendarController.php
+++ b/src/Controller/FullCalendarController.php
@@ -248,7 +248,7 @@ class FullCalendarController extends ControllerBase {
 
     $class = $session->get('field_session_class')->entity;
     $activity = $class->get('field_class_activity')->entity;
-    $color = $activity->get('field_activity_color')->value ??  $this->scheduleManager->getDefaultColor();
+    $color = $activity?->get('field_activity_color')->value ??  $this->scheduleManager->getDefaultColor();
     return new JsonResponse(['id' => $session->id(), 'color' => $color]);
   }
 


### PR DESCRIPTION
Adding a new schedule items with no color set on the activity results in a silent error

- Enable y_pef_schedules
- Open a calendar and add a new item that references a pre-existing Activity.
- Observe item isn’t added, no warning displayed to user (only in console), error in logs:
   > Error: Call to a member function get() on null in Drupal\y_pef_schedule\Controller\FullCalendarController->changeSession() (line 251 of /var/www/docroot/modules/contrib/y_pef_schedule/src/Controller/FullCalendarController.php).

Issue: The module adds a new field to Activities, but existing Activities don’t get that field in the db until they’re saved, so calling get('field_activity_color') fails.